### PR TITLE
Black and White Bits Are Flipped During a Lineart Scan

### DIFF
--- a/src/abstract.py
+++ b/src/abstract.py
@@ -90,9 +90,9 @@ class ImgUtil(object):
             byte = ord(byte)
             for bit in range(7, -1, -1):
                 if ((byte & (1<<bit)) > 0):
-                    raw_unpacked += (chr(0xFF))
-                else:
                     raw_unpacked += (chr(0x00))
+                else:
+                    raw_unpacked += (chr(0xFF))
         assert(len(raw_packed) * 8 == len(raw_unpacked))
         return ImgUtil.__raw_8_to_img(raw_unpacked, mode, pixels_per_line)
 


### PR DESCRIPTION
I noticed when doing a Lineart scan (called "Binary" for the Epson Workforce 545) the black and white bits were being flipped around (image background was black and the text was white). I changed the order of the bytes under the __raw_1_to_img method in ImgUtil and now black and white are rendered correctly.
