### PR TITLE
Filter out examples and tests from packages list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     license="GPLv3+",
     author="Jerome Flesch",
     author_email="jflesch@openpaper.work",
-    packages=find_packages(),
+    packages=find_packages(exclude=['examples','tests']),
     data_files=[],
     scripts=[],
     install_requires=[


### PR DESCRIPTION
find_packages() will add them to the list, but they should not be installed system-wide
Spotted while updating the Gentoo package (checks block the installation of packages called "examples", "tests", ...)