### PR TITLE
daemon.py does not need to be executable.

### DIFF
--- a/pyinsane2/sane/daemon.py
+++ b/pyinsane2/sane/daemon.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import logging
 import os
 import pickle


### PR DESCRIPTION
It is executed through `sys.executable` to provide 2/3 compat, and it's never run directly.