### PR TITLE
Replaced FileNotFoundError with EnvironmentError 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ try:
     print("Pyinsane version: {}".format(version))
     if "-" in version:
         version = version.split("-")[0]
-except FileNotFoundError:
+except EnvironmentError:
     print("ERROR: _version.py file is missing")
     print("ERROR: Please run 'make version' first")
     sys.exit(1)


### PR DESCRIPTION
Replaced FileNotFoundError with EnvironmentError as it produces a readable error on Python 2 or Python 3.

```
python ./setup.py install
Traceback (most recent call last):
  File "./setup.py", line 24, in <module>
    except FileNotFoundError:
NameError: name 'FileNotFoundError' is not defined
```

```
$ python ./setup.py install
ERROR: _version.py file is missing
ERROR: Please run 'make version' first
```
